### PR TITLE
support more sources through specific schemes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  e2e:
+  registry:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,8 +34,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -62,6 +60,72 @@ jobs:
           fi
           set -x
           ./bin/undock ${flags} ${{ matrix.image }} ./dist
+      -
+        name: Dist content
+        run: |
+          tree -nh ./dist
+
+  docker-daemon:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: binary
+      -
+        name: Create Dockerfile
+        run: |
+          mkdir ./bin/test
+          cat > ./bin/test/Dockerfile <<EOL
+          FROM alpine
+          RUN mkdir hello && echo "Hello, world!" > /hello/world
+          EOL
+      -
+        name: Build image and load
+        uses: docker/build-push-action@v2
+        with:
+          context: ./bin/test
+          load: true
+          tags: image:local
+      -
+        name: Run
+        run: |
+          ./bin/undock --rm-dist --include /hello docker-daemon://image:local ./dist
+      -
+        name: Dist content
+        run: |
+          tree -nh ./dist
+
+  docker-archive:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/bake-action@v1
+        with:
+          targets: binary
+      -
+        name: Create docker archive
+        run: |
+          docker pull crazymax/buildx-pkg:latest
+          docker save crazymax/buildx-pkg:latest > archive.tar
+      -
+        name: Run
+        run: |
+          ./bin/undock --rm-dist docker-archive://archive.tar ./dist
       -
         name: Dist content
         run: |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ local machine with a single command.
 
 ## Features
 
+* Many source support (docker, archive, store, oci, tar)
 * Can extract multi-platform images
 * Include a subset of files/dirs
 * Cache support

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@
 
 ---
 
-## What is Undock?
+## What's Undock?
 
 **Undock** is a CLI application that allows you to extract contents of a
 container image in a local folder. This can be useful if you use a registry
@@ -28,6 +28,7 @@ See the [usage examples](usage/examples.md) for more info.
 
 ## Features
 
+* Many source support (docker, archive, store, oci, tar)
 * Can extract multi-platform images
 * Include a subset of files/dirs
 * Cache support

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```shell
-undock [options]
+undock [options] <source> <dist>
 ```
 
 ## Options
@@ -15,7 +15,7 @@ Usage: undock <source> <dist>
 Extract contents of a container image in a local folder. More info: https://github.com/crazy-max/undock
 
 Arguments:
-  <source>    Source image from a registry. (eg. alpine:latest)
+  <source>    Source image. (eg. alpine:latest)
   <dist>      Dist folder. (eg. ./dist)
 
 Flags:
@@ -29,9 +29,41 @@ Flags:
       --platform=STRING        Enforce platform for source image. (eg. linux/amd64)
       --all                    Extract all architectures if source is a manifest list.
       --include=INCLUDE,...    Include a subset of files/dirs from the source image.
-      --insecure               Allow contacting the registry over HTTP, or HTTPS with failed TLS verification.
+      --insecure               Allow contacting the registry or docker daemon over HTTP, or HTTPS with failed TLS verification.
       --rm-dist                Removes dist folder.
       --wrap                   For a manifest list, merge output in dist folder.
+```
+
+### Source image
+
+`source` argument can be a container image from a registry, a local docker
+image, a container store reference, etc. Following schemes can be used:
+
+* `containers-storage://<store>`: image located in a local container storage[^1].
+* `docker://<ref>`: image in a registry implementing the "Docker Registry HTTP API V2"[^1].
+* `docker-archive://<path>`: image is stored in the `docker-save` formatted file[^1].
+* `docker-daemon://<ref>`: image stored in the docker daemon's internal storage[^1].
+* `oci://<path>`: image compliant with the "Open Container Image Layout Specification"[^1].
+* `oci-archive://<path>`: image compliant with the "Open Container Image Layout Specification" stored as a tar archive[^1].
+* `ostree://<ref>`: image in the local ostree repository[^1].
+
+!!! note
+    `docker://` is used by default if scheme unset.
+
+```console
+# registry image
+undock --rm-dist crazymax/buildx-pkg:latest ./dist
+# or
+undock --rm-dist docker://crazymax/buildx-pkg:latest ./dist
+
+# archive docker image
+docker pull crazymax/buildx-pkg:latest
+docker save crazymax/buildx-pkg:latest > archive.tar
+undock --rm-dist docker-archive://archive.tar ./dist
+
+# local docker image
+docker build -t myimage:local .
+undock --rm-dist docker-daemon://myimage:local ./dist
 ```
 
 ## Environment variables
@@ -44,3 +76,5 @@ Following environment variables can be used in place:
 | `LOG_JSON`         | `false`       | Enable JSON logging output |
 | `LOG_CALLER`       | `false`       | Enable to add `file:line` of the caller |
 | `LOG_NOCOLOR`      | `false`       | Disable the colorized output |
+
+[^1]: See [containers image transport page](https://github.com/containers/image/blob/main/docs/containers-transports.5.md) for more info.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kong v0.4.0
 	github.com/containerd/containerd v1.5.9
 	github.com/containers/image/v5 v5.19.1
+	github.com/docker/docker v20.10.12+incompatible
 	github.com/mholt/archiver/v4 v4.0.0-alpha.4
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202193544-a5463b7f9c84
@@ -34,7 +35,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v20.10.12+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -15,10 +15,10 @@ type Cli struct {
 
 	All      bool     `kong:"name=all,default=false,help='Extract all architectures if source is a manifest list.'"`
 	Includes []string `kong:"name=include,help='Include a subset of files/dirs from the source image.'"`
-	Insecure bool     `kong:"name=insecure,default=false,help='Allow contacting the registry over HTTP, or HTTPS with failed TLS verification.'"`
+	Insecure bool     `kong:"name=insecure,default=false,help='Allow contacting the registry or docker daemon over HTTP, or HTTPS with failed TLS verification.'"`
 	RmDist   bool     `kong:"name=rm-dist,default=false,help='Removes dist folder.'"`
 	Wrap     bool     `kong:"name=wrap,default=false,help='For a manifest list, merge output in dist folder.'"`
 
-	Source string `kong:"arg,required,name=source,help='Source image from a registry. (eg. alpine:latest)'"`
+	Source string `kong:"arg,required,name=source,help='Source image. (eg. alpine:latest)'"`
 	Dist   string `kong:"arg,required,name=dist,type=path,help='Dist folder. (eg. ./dist)'"`
 }

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -1,0 +1,12 @@
+package extractor
+
+// Handler is an extractor interface
+type Handler interface {
+	Extract() error
+	Type() string
+}
+
+// Client represents an active extractor object
+type Client struct {
+	Handler
+}

--- a/internal/extractor/image/image.go
+++ b/internal/extractor/image/image.go
@@ -1,0 +1,145 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/containers/image/v5/manifest"
+	"github.com/crazy-max/undock/internal/config"
+	"github.com/crazy-max/undock/internal/extractor"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
+)
+
+// Client represents an active image extractor object
+type Client struct {
+	*extractor.Client
+	ctx      context.Context
+	meta     config.Meta
+	cli      config.Cli
+	platform specs.Platform
+	logger   zerolog.Logger
+}
+
+// New creates new image extractor instance
+func New(ctx context.Context, meta config.Meta, cli config.Cli, platform specs.Platform) (*extractor.Client, error) {
+	return &extractor.Client{
+		Handler: &Client{
+			ctx:      ctx,
+			meta:     meta,
+			cli:      cli,
+			platform: platform,
+			logger:   log.With().Str("src", cli.Source).Logger(),
+		},
+	}, nil
+}
+
+// Type returns the extractor type
+func (c *Client) Type() string {
+	return "image"
+}
+
+// Extract extracts a registry image
+func (c *Client) Extract() error {
+	c.logger.Info().Msg("Extracting source")
+
+	manblob, cachedir, err := c.cacheSource(c.cli.Source)
+	if err != nil {
+		return errors.Wrap(err, "cannot cache source")
+	}
+
+	type manifestEntry struct {
+		platform specs.Platform
+		manifest *manifest.OCI1
+	}
+
+	var mans []manifestEntry
+
+	mtype := manifest.GuessMIMEType(manblob)
+	if mtype == specs.MediaTypeImageManifest {
+		man, err := manifest.OCI1FromManifest(manblob)
+		if err != nil {
+			return errors.Wrap(err, "cannot create OCI manifest instance from blob")
+		}
+		mans = append(mans, manifestEntry{
+			platform: c.platform,
+			manifest: man,
+		})
+	} else if mtype == specs.MediaTypeImageIndex {
+		ocindex, err := manifest.OCI1IndexFromManifest(manblob)
+		if err != nil {
+			return errors.Wrap(err, "cannot create OCI manifest index instance from blob")
+		}
+		for _, m := range ocindex.Manifests {
+			mblob, err := os.ReadFile(path.Join(cachedir, "blobs", m.Digest.Algorithm().String(), m.Digest.Hex()))
+			if err != nil {
+				return errors.Wrapf(err, "cannot read OCI manifest JSON for platform %s", platforms.Format(*m.Platform))
+			}
+			man, err := manifest.OCI1FromManifest(mblob)
+			if err != nil {
+				return errors.Wrap(err, "cannot create OCI manifest instance from blob")
+			}
+			mans = append(mans, manifestEntry{
+				platform: *m.Platform,
+				manifest: man,
+			})
+		}
+	}
+
+	eg, _ := errgroup.WithContext(c.ctx)
+	for _, mane := range mans {
+		func(mane manifestEntry) {
+			eg.Go(func() error {
+				dest := c.cli.Dist
+				if !c.cli.Wrap && len(mans) > 1 {
+					dest = path.Join(c.cli.Dist, fmt.Sprintf("%s_%s%s", mane.platform.OS, mane.platform.Architecture, mane.platform.Variant))
+				}
+				if err := os.MkdirAll(dest, 0o700); err != nil {
+					return errors.Wrapf(err, "failed to create destination folder %q", dest)
+				}
+				for _, layer := range mane.manifest.LayerInfos() {
+					sublogger := c.logger.With().Str("platform", platforms.Format(mane.platform)).Str("blob", layer.Digest.String()).Logger()
+					if err = extractor.ExtractBlob(path.Join(cachedir, "blobs", layer.Digest.Algorithm().String(), layer.Digest.Hex()), dest, extractor.ExtractBlobOpts{
+						Context:  c.ctx,
+						Logger:   sublogger,
+						Includes: c.cli.Includes,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		}(mane)
+	}
+
+	return eg.Wait()
+}
+
+func formatReference(source string) (string, string) {
+	scheme := sourceScheme(source)
+	switch scheme {
+	case "":
+		return "docker://" + source, "docker"
+	case "docker":
+		return source, scheme
+	default:
+		return strings.Replace(source, scheme+"://", scheme+":", 1), scheme
+	}
+}
+
+func sourceScheme(source string) string {
+	schemes := []string{"containers-storage", "docker", "docker-archive", "docker-daemon", "oci", "oci-archive", "ostree"}
+	for _, scheme := range schemes {
+		if strings.HasPrefix(source, scheme+"://") {
+			return scheme
+		}
+	}
+	return ""
+}

--- a/internal/extractor/image/source.go
+++ b/internal/extractor/image/source.go
@@ -1,0 +1,55 @@
+package image
+
+import (
+	"strings"
+
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
+)
+
+var sourceSchemes = []string{"containers-storage", "docker", "docker-archive", "docker-daemon", "oci", "oci-archive", "ostree"}
+
+type Source struct {
+	name string
+}
+
+func NewSource(name string) *Source {
+	return &Source{
+		name: name,
+	}
+}
+
+func (s *Source) Scheme() string {
+	for _, scheme := range sourceSchemes {
+		if strings.HasPrefix(s.name, scheme+"://") {
+			return scheme
+		}
+	}
+	return "docker"
+}
+
+func (s *Source) HasScheme() bool {
+	for _, scheme := range sourceSchemes {
+		if strings.HasPrefix(s.name, scheme+"://") {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Source) Reference() (types.ImageReference, error) {
+	return alltransports.ParseImageName(s.String())
+}
+
+func (s *Source) String() string {
+	if !s.HasScheme() {
+		return "docker://" + s.name
+	}
+	scheme := s.Scheme()
+	switch scheme {
+	case "docker":
+		return s.name
+	default:
+		return strings.Replace(s.name, scheme+"://", scheme+":", 1)
+	}
+}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -1,0 +1,35 @@
+package docker
+
+import (
+	"context"
+
+	dockercli "github.com/docker/docker/client"
+)
+
+// Client represents an active docker object
+type Client struct {
+	ctx context.Context
+	*dockercli.Client
+}
+
+// New initializes a new Docker API client from env
+func New(ctx context.Context) (*Client, error) {
+	cli, err := dockercli.NewClientWithOpts(dockercli.FromEnv, dockercli.WithVersion("1.12"))
+	if err != nil {
+		return nil, err
+	}
+	if _, err = cli.ServerVersion(ctx); err != nil {
+		return nil, err
+	}
+	return &Client{
+		ctx:    ctx,
+		Client: cli,
+	}, err
+}
+
+// Close closes the docker client
+func (c *Client) Close() {
+	if c.Client != nil {
+		_ = c.Client.Close()
+	}
+}

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -1,0 +1,35 @@
+package docker
+
+import (
+	"regexp"
+
+	"github.com/docker/docker/api/types"
+)
+
+// ContainerInspect returns the container information.
+func (c *Client) ContainerInspect(containerID string) (types.ContainerJSON, error) {
+	return c.Client.ContainerInspect(c.ctx, containerID)
+}
+
+// IsDigest determines image it looks like a digest based image reference.
+func (c *Client) IsDigest(imageID string) bool {
+	return regexp.MustCompile(`^(@|sha256:|@sha256:)([0-9a-f]{64})$`).MatchString(imageID)
+}
+
+// ImageInspectWithRaw returns the image information and its raw representation.
+func (c *Client) ImageInspectWithRaw(imageID string) (types.ImageInspect, error) {
+	imageRaw, _, err := c.Client.ImageInspectWithRaw(c.ctx, imageID)
+	return imageRaw, err
+}
+
+// IsLocalImage checks if the image has been built locally
+func (c *Client) IsLocalImage(image types.ImageInspect) bool {
+	return len(image.RepoDigests) == 0
+}
+
+// IsDanglingImage returns whether the given image is "dangling" which means
+// that there are no repository references to the given image, and it has no
+// child images
+func (c *Client) IsDanglingImage(image types.ImageInspect) bool {
+	return len(image.RepoTags) == 1 && image.RepoTags[0] == "<none>:<none>" && len(image.RepoDigests) == 1 && image.RepoDigests[0] == "<none>@<none>"
+}


### PR DESCRIPTION
Now `source` argument can be a container image from a registry, a local docker
image, a container store reference, etc. Following schemes can be used:

* `containers-storage://<store>`: image located in a local container storage.
* `docker://<ref>`: image in a registry implementing the "Docker Registry HTTP API V2".
* `docker-archive://<path>`: image is stored in the `docker-save` formatted file.
* `docker-daemon://<ref>`: image stored in the docker daemon's internal storage.
* `oci://<path>`: image compliant with the "Open Container Image Layout Specification".
* `oci-archive://<path>`: image compliant with the "Open Container Image Layout Specification" stored as a tar archive.
* `ostree://<ref>`: image in the local ostree repository.