### PR TITLE
chore: use repository placeholder of github context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   DOCKERHUB_SLUG: crazymax/undock
-  GHCR_SLUG: ghcr.io/crazy-max/undock
+  GHCR_SLUG: ghcr.io/${{ github.repository }}
 
 jobs:
   validate:


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

To provide a better consistency for forks, it'd be better to use a `repository` placeholder for replacement in `GHCR_SLUG`