### PR TITLE
mkdocs: pin dependencies

### DIFF
--- a/hack/docs.Dockerfile
+++ b/hack/docs.Dockerfile
@@ -6,12 +6,12 @@ FROM squidfunk/mkdocs-material:${MKDOCS_VERSION} AS base
 RUN apk add --no-cache git git-fast-import openssl \
   && apk add --no-cache --virtual .build gcc musl-dev \
   && pip install --no-cache-dir \
-    'lunr' \
-    'markdown-include' \
-    'mkdocs-awesome-pages-plugin' \
-    'mkdocs-exclude' \
-    'mkdocs-git-revision-date-localized-plugin' \
-    'mkdocs-macros-plugin' \
+    'lunr==0.7.0' \
+    'markdown-include==0.8.1' \
+    'mkdocs-awesome-pages-plugin==2.9.3' \
+    'mkdocs-exclude==1.0.2' \
+    'mkdocs-git-revision-date-localized-plugin==1.3.0' \
+    'mkdocs-macros-plugin==1.3.7' \
   && apk del .build gcc musl-dev \
   && rm -rf /tmp/*
 


### PR DESCRIPTION
relates to https://github.com/crazy-max/undock/actions/runs/14517134304/job/40728765186#step:4:430

```
#12 [generate 1/1] RUN --mount=type=bind,target=.   mkdocs build --strict --site-dir /out
#12 1.279 Traceback (most recent call last):
#12 1.279   File "/usr/local/bin/mkdocs", line 8, in <module>
#12 1.279     sys.exit(cli())
#12 1.279   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
#12 1.279     return self.main(*args, **kwargs)
#12 1.279   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1062, in main
#12 1.280     rv = self.invoke(ctx)
#12 1.280   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
#12 1.281     return _process_result(sub_ctx.command.invoke(sub_ctx))
#12 1.281   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
#12 1.281     return ctx.invoke(self.callback, **ctx.params)
#12 1.281   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 763, in invoke
#12 1.282     return __callback(*args, **kwargs)
#12 1.282   File "/usr/local/lib/python3.9/site-packages/mkdocs/__main__.py", line 183, in build_command
#12 1.282     build.build(config.load_config(**kwargs), dirty=not clean)
#12 1.282   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/base.py", line 224, in load_config
#12 1.282     errors, warnings = cfg.validate()
#12 1.282   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/base.py", line 108, in validate
#12 1.282     run_failed, run_warnings = self._validate()
#12 1.282   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/base.py", line 63, in _validate
#12 1.282     self[key] = config_option.validate(value)
#12 1.282   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/config_options.py", line 130, in validate
#12 1.283     return self.run_validation(value)
#12 1.283   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/config_options.py", line 636, in run_validation
#12 1.283     plgins[item] = self.load_plugin(item, cfg)
#12 1.283   File "/usr/local/lib/python3.9/site-packages/mkdocs/config/config_options.py", line 649, in load_plugin
#12 1.283     Plugin = self.installed_plugins[name].load()
#12 1.283   File "/usr/local/lib/python3.9/site-packages/importlib_metadata/__init__.py", line 194, in load
#12 1.283     module = import_module(match.group('module'))
#12 1.283   File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
#12 1.284     return _bootstrap._gcd_import(name[level:], package, level)
#12 1.284   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
#12 1.284   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
#12 1.284   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
#12 1.284   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
#12 1.284   File "<frozen importlib._bootstrap_external>", line 790, in exec_module
#12 1.284   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
#12 1.284   File "/usr/local/lib/python3.9/site-packages/mkdocs_git_revision_date_localized_plugin/plugin.py", line 21, in <module>
#12 1.284     from mkdocs.config.defaults import MkDocsConfig
#12 1.284 ImportError: cannot import name 'MkDocsConfig' from 'mkdocs.config.defaults' (/usr/local/lib/python3.9/site-packages/mkdocs/config/defaults.py)
#12 ERROR: process "/bin/sh -c mkdocs build --strict --site-dir /out" did not complete successfully: exit code: 1
```